### PR TITLE
Add optional work_path to public functions to avoid potential permission issue 

### DIFF
--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -12,9 +12,6 @@ import re
 
 
 def get_symbol_list(symbol_data,exchange_name):
-    
-    csv_file = exchange_name +'.csv'    
-    
     symbol_list = list()
     symbol_data = symbol_data.replace('"', "")
     symbol_data = re.split("\r?\n", symbol_data)
@@ -22,15 +19,14 @@ def get_symbol_list(symbol_data,exchange_name):
     headers = symbol_data[0]
     #symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
-    # We need to cut off the the last row because it is a null string
+    # We need to cut off the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()
         symbol_data_dict['symbol'] = row[0] 
         symbol_data_dict['company'] = row[1] 
         symbol_data_dict['sector'] = row[6] 
         symbol_data_dict['industry'] = row[7] 
-        symbol_data_dict['industry'] = row[7] 
-
+        #   append symbol data dictionary
         symbol_list.append(symbol_data_dict)
     return symbol_list
 
@@ -89,3 +85,4 @@ def wiki_html(url,file_path):
         #Save file to be used by cache
         save_file(file_path,wiki_html)
         return wiki_html
+

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -73,16 +73,14 @@ def fetch_file(url):
     elif isinstance(file_data, bytes):  # Python3
         return file_data.decode("utf-8")
 
-
-def wiki_html(url,file_name):
+#   use full file path here
+def wiki_html(url,file_path):
     '''
     Obtains html from Wikipedia
     Note: API exist but for my use case. Data returned was not parsable. Preferred to use html
     python-wikitools - http://code.google.com/p/python-wikitools/
     Ex. http://en.wikipedia.org/w/api.php?format=xml&action=query&titles=List_of_S%26P_500_companies&prop=revisions&rvprop=content
     '''
-    file_path = os.path.join(os.path.dirname(finsymbols.__file__), file_name)
-
     if is_cached(file_path):
         with open(file_path, "r") as sp500_file:
             return sp500_file.read()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -34,9 +34,9 @@ def get_symbol_list(symbol_data,exchange_name):
         symbol_list.append(symbol_data_dict)
     return symbol_list
 
-def save_file(file_path,file_name):
+def save_file(file_path,file_content):
     saved_file = open(file_path , "w")
-    saved_file.write(file_name)
+    saved_file.write(file_content)
     saved_file.close()
 
 def get_exchange_url(exchange):

--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -7,7 +7,9 @@ from finsymbols.symbol_helper import *
 
 
 #   pass in working path to avoid potential permission error
-def get_sp500_symbols(work_path=os.path.dirname(finsymbols.__file__)):
+def get_sp500_symbols(work_path=""):
+    if not work_path:
+        work_path = _get_default_work_path()
     page_html = wiki_html('List_of_S%26P_500_companies', os.path.join(work_path, 'SP500.html'))
     wiki_soup = BeautifulSoup(page_html, "html.parser")
     symbol_table = wiki_soup.find(attrs={'class': 'wikitable sortable'})
@@ -60,3 +62,7 @@ def _get_exchange_data(exchange):
       save_file(file_path,symbol_data)
     
     return get_symbol_list(symbol_data,exchange)
+
+def _get_default_work_path():
+    return os.path.dirname(finsymbols.__file__)
+

--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -7,33 +7,33 @@ from finsymbols.symbol_helper import *
 
 
 def get_sp500_symbols():
-	page_html = wiki_html('List_of_S%26P_500_companies','SP500.html')
-	wiki_soup = BeautifulSoup(page_html, "html.parser")
-	symbol_table = wiki_soup.find(attrs={'class': 'wikitable sortable'})
+    page_html = wiki_html('List_of_S%26P_500_companies','SP500.html')
+    wiki_soup = BeautifulSoup(page_html, "html.parser")
+    symbol_table = wiki_soup.find(attrs={'class': 'wikitable sortable'})
 
-	symbol_data_list = list()
+    symbol_data_list = list()
 
-	for symbol in symbol_table.find_all("tr"):
-		symbol_data_content = dict()
-		symbol_raw_data = symbol.find_all("td")
-		td_count = 0
-		for symbol_data in symbol_raw_data:
-			if(td_count == 0):
-				symbol_data_content['symbol'] = symbol_data.text.encode('utf-8')
-			elif(td_count == 1):
-				symbol_data_content['company'] = symbol_data.text.encode('utf-8')
-			elif(td_count == 3):
-				symbol_data_content['sector'] = symbol_data.text.encode('utf-8')
-			elif(td_count == 4):
-				symbol_data_content['industry'] = symbol_data.text.encode('utf-8')
-			elif(td_count == 5):
-				symbol_data_content['headquaters'] = symbol_data.text.encode('utf-8')
+    for symbol in symbol_table.find_all("tr"):
+        symbol_data_content = dict()
+        symbol_raw_data = symbol.find_all("td")
+        td_count = 0
+        for symbol_data in symbol_raw_data:
+            if(td_count == 0):
+                symbol_data_content['symbol'] = symbol_data.text.encode('utf-8')
+            elif(td_count == 1):
+                symbol_data_content['company'] = symbol_data.text.encode('utf-8')
+            elif(td_count == 3):
+                symbol_data_content['sector'] = symbol_data.text.encode('utf-8')
+            elif(td_count == 4):
+                symbol_data_content['industry'] = symbol_data.text.encode('utf-8')
+            elif(td_count == 5):
+                symbol_data_content['headquaters'] = symbol_data.text.encode('utf-8')
 
-			td_count += 1
+            td_count += 1
 
-		symbol_data_list.append(symbol_data_content)
+        symbol_data_list.append(symbol_data_content)
 
-	return symbol_data_list[1::]
+    return symbol_data_list[1::]
 
 
 def get_nyse_symbols():

--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -6,8 +6,9 @@ from bs4 import BeautifulSoup
 from finsymbols.symbol_helper import *
 
 
-def get_sp500_symbols():
-    page_html = wiki_html('List_of_S%26P_500_companies','SP500.html')
+#   pass in working path to avoid potential permission error
+def get_sp500_symbols(work_path=os.path.dirname(finsymbols.__file__)):
+    page_html = wiki_html('List_of_S%26P_500_companies', os.path.join(work_path, 'SP500.html'))
     wiki_soup = BeautifulSoup(page_html, "html.parser")
     symbol_table = wiki_soup.find(attrs={'class': 'wikitable sortable'})
 

--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -39,29 +39,36 @@ def get_sp500_symbols(work_path=""):
     return symbol_data_list[1::]
 
 
-def get_nyse_symbols():
-    return _get_exchange_data("NYSE")
+def get_nyse_symbols(work_path=""):
+    if not work_path:
+        work_path = _get_default_work_path()
+    return _get_exchange_data("NYSE", work_path)
 
 
-def get_amex_symbols():
-    return _get_exchange_data("AMEX")
+def get_amex_symbols(work_path=""):
+    if not work_path:
+        work_path = _get_default_work_path()
+    return _get_exchange_data("AMEX", work_path)
 
 
-def get_nasdaq_symbols():
-    return _get_exchange_data("NASDAQ")
+def get_nasdaq_symbols(work_path=""):
+    if not work_path:
+        work_path = _get_default_work_path()
+    return _get_exchange_data("NASDAQ", work_path)
 
 
-def _get_exchange_data(exchange):
+def _get_exchange_data(exchange, work_path):
     url = get_exchange_url(exchange)
-    file_path = os.path.join(os.path.dirname(finsymbols.__file__), exchange)
+    file_path = os.path.join(work_path, exchange)
     if is_cached(file_path):
         with open(file_path, "r") as cached_file:
             symbol_data = cached_file.read()
     else:
       symbol_data = fetch_file(url)
-      save_file(file_path,symbol_data)
+      save_file(file_path, symbol_data)
     
-    return get_symbol_list(symbol_data,exchange)
+    return get_symbol_list(symbol_data, exchange)
+
 
 def _get_default_work_path():
     return os.path.dirname(finsymbols.__file__)


### PR DESCRIPTION
In previous implementation, the temporary path of downloaded web pages are fixed to the install path of finsymbols. In my Linux system, root permission is needed to created files in the package install path. As a result, I add optional parameter work_dir to public functions, so caller could specified local path (with write permission) to store the downloaded web pages, avoiding permission issues or additional environment variable set up. 