### PR TITLE
removed explicit encoding

### DIFF
--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -19,15 +19,15 @@ def get_sp500_symbols():
 		td_count = 0
 		for symbol_data in symbol_raw_data:
 			if(td_count == 0):
-				symbol_data_content['symbol'] = symbol_data.text.encode('utf-8')
+				symbol_data_content['symbol'] = symbol_data.text
 			elif(td_count == 1):
-				symbol_data_content['company'] = symbol_data.text.encode('utf-8')
+				symbol_data_content['company'] = symbol_data.text
 			elif(td_count == 3):
-				symbol_data_content['sector'] = symbol_data.text.encode('utf-8')
+				symbol_data_content['sector'] = symbol_data.text
 			elif(td_count == 4):
-				symbol_data_content['industry'] = symbol_data.text.encode('utf-8')
+				symbol_data_content['industry'] = symbol_data.text
 			elif(td_count == 5):
-				symbol_data_content['headquaters'] = symbol_data.text.encode('utf-8')
+				symbol_data_content['headquaters'] = symbol_data.text
 
 			td_count += 1
 


### PR DESCRIPTION
Python 3 appears to be able to parse the strings without explicit encoding.  When I ran `finsymbols.get_sp500_symbols()` in Jupyter with Python 3, each value in the dict pair was byte encoded.  By removing `encode` from the `get_sp500_symbols()` method, everything comes out as expected.