### PR TITLE
removed duplicate line and enhanced parsing cvs format

### DIFF
--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -16,12 +16,11 @@ def get_symbol_list(symbol_data, exchange_name):
     csv_file = exchange_name + '.csv'
 
     symbol_list = list()
-    symbol_data = symbol_data.replace('"', "")
     symbol_data = re.split("\r?\n", symbol_data)
 
     headers = symbol_data[0]
     # symbol,company,sector,industry,headquaters
-    symbol_data = list(map(lambda x: x.split(","), symbol_data))
+    symbol_data = list(csv.reader(symbol_data, delimiter=','))
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()
@@ -29,8 +28,7 @@ def get_symbol_list(symbol_data, exchange_name):
         symbol_data_dict['company'] = row[1]
         symbol_data_dict['sector'] = row[6]
         symbol_data_dict['industry'] = row[7]
-        symbol_data_dict['industry'] = row[7]
-
+     
         symbol_list.append(symbol_data_dict)
     return symbol_list
 

--- a/finsymbols/tests/symbols_test.py
+++ b/finsymbols/tests/symbols_test.py
@@ -11,7 +11,7 @@ class TestSizeOfList(TestCase):
     def test_sp500_size(self):
         sp500 = symbols.get_sp500_symbols()
         assert len(sp500) == 504, 'len gathered data: {}.\
-         Expected len: 504'.format(len(sp500))
+         Expected len: 505'.format(len(sp500))
 
     def test_amex_not_null(self):
         amex = symbols.get_amex_symbols()

--- a/finsymbols/tests/symbols_test.py
+++ b/finsymbols/tests/symbols_test.py
@@ -10,7 +10,7 @@ class TestSizeOfList(TestCase):
 
     def test_sp500_size(self):
         sp500 = symbols.get_sp500_symbols()
-        assert len(sp500) == 504, 'len gathered data: {}.\
+        assert len(sp500) == 505, 'len gathered data: {}.\
          Expected len: 505'.format(len(sp500))
 
     def test_amex_not_null(self):


### PR DESCRIPTION
1. Removed duplicate line: 

`symbol_data_dict['industry'] = row[7]`
1. Using cvs.reader. Now we can also have company names with **,** inside their name like "1-800 FLOWERS.COM**,** Inc." By using the cvs reader we can also drop the workaround line:

`symbol_data = symbol_data.replace('"', "")`

Hope this helps :-)
