### PR TITLE
Remove empty rows/lists from symbol_data

### DIFF
--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -22,7 +22,8 @@ def get_symbol_list(symbol_data, exchange_name):
     headers = symbol_data[0]
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
-    symbol_data = [x for x in symbol_data if len(x) > 1]
+    # remove any blank lists from within the list 
+	symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -22,8 +22,7 @@ def get_symbol_list(symbol_data, exchange_name):
     headers = symbol_data[0]
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
-    # remove any blank lists from within the list 
-	symbol_data = [x for x in symbol_data if len(x) > 1]
+    symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -22,6 +22,7 @@ def get_symbol_list(symbol_data, exchange_name):
     headers = symbol_data[0]
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
+    symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -23,7 +23,7 @@ def get_symbol_list(symbol_data, exchange_name):
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
     # remove any blank lists from within the list 
-symbol_data = [x for x in symbol_data if len(x) > 1]
+    symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -23,7 +23,7 @@ def get_symbol_list(symbol_data, exchange_name):
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
     # remove any blank lists from within the list 
-    symbol_data = [x for x in symbol_data if len(x) > 1]
+symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:
         symbol_data_dict = dict()

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -22,6 +22,7 @@ def get_symbol_list(symbol_data, exchange_name):
     headers = symbol_data[0]
     # symbol,company,sector,industry,headquaters
     symbol_data = list(map(lambda x: x.split(","), symbol_data))
+    # remove any blank lists from within the list 
     symbol_data = [x for x in symbol_data if len(x) > 1]
     # We need to cut off the the last row because it is a null string
     for row in symbol_data[1:-1]:

--- a/finsymbols/tests/symbols_test.py
+++ b/finsymbols/tests/symbols_test.py
@@ -10,7 +10,7 @@ class TestSizeOfList(TestCase):
 
     def test_sp500_size(self):
         sp500 = symbols.get_sp500_symbols()
-        assert len(sp500) == 504, 'len gathered data: {}.\
+        assert len(sp500) == 505, 'len gathered data: {}.\
          Expected len: 504'.format(len(sp500))
 
     def test_amex_not_null(self):


### PR DESCRIPTION
When pulling in saved files (nyse, amex, nasdaq) symbol_data contained
empty lists within the list. When processed in the loop, I would get an
error that the list index was out of range. My list concatenation fix
will remove any blank lists that could cause this error. 