### PR TITLE
windows fix for file i/o

### DIFF
--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -33,10 +33,9 @@ def get_symbol_list(symbol_data, exchange_name):
     return symbol_list
 
 
-def save_file(file_path, file_name):
-    saved_file = open(file_path, "w")
-    saved_file.write(file_name)
-    saved_file.close()
+def save_file(file_path, file_data):
+    with open(file_path, "wb") as saved_file:
+        saved_file.write(file_data.encode('utf-8'))
 
 
 def get_exchange_url(exchange):
@@ -84,10 +83,10 @@ def wiki_html(url, file_name):
     file_path = os.path.join(os.path.dirname(finsymbols.__file__), file_name)
 
     if is_cached(file_path):
-        with open(file_path, "r") as sp500_file:
+        with open(file_path, "rb") as sp500_file:
             return sp500_file.read()
     else:
-        wiki_html = fetch_file('http://en.wikipedia.org/wiki/' + str(url))
+        wiki_html = fetch_file('http://en.wikipedia.org/wiki/{}'.format(url))
         # Save file to be used by cache
         save_file(file_path, wiki_html)
         return wiki_html

--- a/finsymbols/symbol_helper.py
+++ b/finsymbols/symbol_helper.py
@@ -34,8 +34,12 @@ def get_symbol_list(symbol_data, exchange_name):
 
 
 def save_file(file_path, file_data):
-    with open(file_path, "wb") as saved_file:
-        saved_file.write(file_data.encode('utf-8'))
+    if isinstance(file_data, str):
+        with open(file_path, "w") as saved_file:
+            saved_file.write(file_data)
+    elif isinstance(file_data, bytes):
+        with open(file_path, "wb") as saved_file:
+            saved_file.write(file_data.encode('utf-8'))
 
 
 def get_exchange_url(exchange):


### PR DESCRIPTION
Windows was throwing unicode errors when it tried to write/read file. So not sure if it was windows py3/py2 str vs bytes or a combination that caused it not to work. But think this takes care of it. Used travis to check py2, don't have it built to check