### PR TITLE
Slight caching improvements

### DIFF
--- a/finsymbols/symbols.py
+++ b/finsymbols/symbols.py
@@ -1,5 +1,3 @@
-import pprint
-import sys
 from bs4 import BeautifulSoup
 from finsymbols.symbol_helper import *
 
@@ -59,6 +57,9 @@ def _get_exchange_data(exchange):
             symbol_data = cached_file.read()
     else:
         symbol_data = fetch_file(url)
-        save_file(file_path, symbol_data)
+        if symbol_data:
+            save_file(file_path, symbol_data)
+        else:
+            raise SymbolFetchException
 
-    return get_symbol_list(symbol_data, exchange)
+    return get_symbol_list(symbol_data)


### PR DESCRIPTION
I was having some issues using `finsymbols` in an office with a slightly dodgy WiFi:
1. `get_sp500_symbols()` returned an empty list.
2. I opened an internet browser and noticed that my WiFi was flaky, so re-connected to the network.
3. `get_sp500_symbols()` kept returning empty lists even though the internet browser was now working fine.

When I debugged the problem, it turned out that the wiki page for S&P500 was cached as an empty string. Hence I couldn't actually get the symbols until I manually cleared the cache.

The changes in the pull request address the above issue in the following way:
1. Only cache HTML if it is nonempty.
2. If an HTML fetch failed, raise an exception. That way users won't mistakenly blame the module for what is probably a network issue.

I also made a few small [PEP8](https://www.python.org/dev/peps/pep-0008/#documentation-strings)-compliance changes (e.g. double-quotes instead of single quotes for docstrings).